### PR TITLE
feat: require bootstrap for configuration update

### DIFF
--- a/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
+++ b/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
@@ -376,7 +376,7 @@ public class PKCS11CryptoKeyService extends PluginService implements CryptoKeySp
             logger.atTrace().log("PKCS11 library path changes, requires bootstrap");
             return true;
         }
-        if (!Integer.valueOf(slotId).equals(newConfiguration.get(SLOT_ID_TOPIC))) {
+        if (!Integer.valueOf(slotId).equals(Coerce.toInt(newConfiguration.get(SLOT_ID_TOPIC)))) {
             logger.atTrace().log("PKCS11 slot id changes, requires bootstrap");
             return true;
         }

--- a/src/test/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyServiceIntegrationTest.java
+++ b/src/test/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyServiceIntegrationTest.java
@@ -346,6 +346,22 @@ class PKCS11CryptoKeyServiceIntegrationTest extends BaseITCase {
     }
 
     @Test
+    void GIVEN_slot_id_change_in_string_WHEN_bootstrap_required_THEN_return_true() throws Exception {
+        startServiceExpectRunning();
+        PKCS11CryptoKeyService service =
+                (PKCS11CryptoKeyService) kernel.locate(PKCS11CryptoKeyService.PKCS11_SERVICE_NAME);
+        Map<String, Object> newServiceConfig = new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "0.0.0");
+            put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
+                put(PKCS11CryptoKeyService.LIBRARY_TOPIC, hsm.getSharedLibraryPath().toString());
+                put(PKCS11CryptoKeyService.SLOT_ID_TOPIC, String.valueOf(token.getSlotId()+1));
+                put(PKCS11CryptoKeyService.USER_PIN_TOPIC, token.getUserPin());
+            }});
+        }};
+        assertThat(service.isBootstrapRequired(newServiceConfig), Is.is(true));
+    }
+
+    @Test
     void GIVEN_user_pin_change_WHEN_bootstrap_required_THEN_return_true() throws Exception {
         startServiceExpectRunning();
         PKCS11CryptoKeyService service =


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Alway require bootstrapping for pkcs11 plugin configuration change, so plugin component will restart nucleus. Greengrass TPM use cases then will use updated pkcs11 configuration for cryptographic operations.

**Why is this change necessary:**
Since security service is API based, when its configuration is changed, the API caller needs to refresh the call to take the new configuration. Instead of notifying the individual caller, the plugin can inform nucleus to restart so the use cases will pick up the configuration change.

**How was this change tested:**
Will add UATs for the scenario

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
