### PR TITLE
fix: hide sensitive config values from exception stack-trace in case of malformed config

### DIFF
--- a/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
+++ b/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
@@ -133,6 +133,7 @@ public class PKCS11CryptoKeyService extends PluginService implements CryptoKeySp
         this.securityService = securityService;
     }
 
+    @SuppressWarnings("PMD.PreserveStackTrace")
     @Override
     protected void install() throws InterruptedException {
         try {
@@ -142,8 +143,8 @@ public class PKCS11CryptoKeyService extends PluginService implements CryptoKeySp
             this.config.lookup(CONFIGURATION_CONFIG_KEY, SLOT_ID_TOPIC).subscribe(this::updateSlotId);
             this.config.lookup(CONFIGURATION_CONFIG_KEY, USER_PIN_TOPIC).subscribe(this::updateUserPin);
         } catch (IllegalArgumentException e) {
-            throw new RuntimeException(String.format("Failed to install PKCSCryptoKeyService. "
-                    + "Please check the configuration for %s service in your configuration file", PKCS11_SERVICE_NAME));
+            throw new RuntimeException(String.format("Failed to install PKCS11CryptoKeyService. "
+                    + "Make sure that configuration format for %s service is valid.", PKCS11_SERVICE_NAME));
         }
         if (!initializePkcs11Lib() || !initializePkcs11Provider()) {
             serviceErrored("Can't initialize PKCS11");


### PR DESCRIPTION
**Issue #, if available:** During installation, malformed PKCS11CryptoService configuration triggers exception with sensitive config values such as `userPin` in it's stacktrace, which might end up in log files leading to security issues: [CWE-532](https://cwe.mitre.org/data/definitions/532.html)

**Description of changes:** re-throws IllegalArgumentArgumentException with generic exception message without sensitive config values.

**How was this change tested:** 
- `mvn clean verify`
- verified with UATs

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
