### PR TITLE
fix: include input uri in uri-parsing exception message

### DIFF
--- a/src/main/java/com/aws/greengrass/security/provider/pkcs11/Pkcs11URI.java
+++ b/src/main/java/com/aws/greengrass/security/provider/pkcs11/Pkcs11URI.java
@@ -41,7 +41,7 @@ public class Pkcs11URI {
     public Pkcs11URI(URI uri) {
         this.uri = uri;
         if (!PKCS11_SCHEME.equalsIgnoreCase(this.uri.getScheme())) {
-            throw new IllegalArgumentException(String.format("URI scheme part is not %s", PKCS11_SCHEME));
+            throw new IllegalArgumentException(String.format("URI scheme is not %s: %s", PKCS11_SCHEME, uri));
         }
         parseAttributes(this.uri.getSchemeSpecificPart());
     }

--- a/src/test/java/com/aws/greengrass/security/provider/pkcs11/Pkcs11URITest.java
+++ b/src/test/java/com/aws/greengrass/security/provider/pkcs11/Pkcs11URITest.java
@@ -11,9 +11,11 @@ import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(GGExtension.class)
@@ -44,7 +46,9 @@ class Pkcs11URITest {
 
     @Test
     void GIVEN_file_uri_WHEN_create_object_THEN_throw_exception() {
-        assertThrows(IllegalArgumentException.class,  () -> new Pkcs11URI("file:///path/to/file"));
+        String path = "file:///path/to/file";
+        Exception e = assertThrows(IllegalArgumentException.class,  () -> new Pkcs11URI(URI.create(path)));
+        assertThat(e.getMessage(), containsString("URI scheme is not pkcs11: " + path));
     }
 
     @Test


### PR DESCRIPTION
**Description of changes:** Adds input uri in uri-parsing exception message for easy debugging

**How was this change tested:** `mvn verify`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
