### PR TITLE
fix: use coerce tostring instead of string casting

### DIFF
--- a/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
+++ b/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
@@ -439,8 +439,8 @@ public class PKCS11CryptoKeyService extends PluginService implements CryptoKeySp
             logger.atTrace().log("PKCS11 slot id changes, requires bootstrap");
             return true;
         }
-        char[] updatedUserPin = newConfiguration.get(USER_PIN_TOPIC) == null ? null
-                : ((String) newConfiguration.get(USER_PIN_TOPIC)).toCharArray();
+        char[] updatedUserPin = Coerce.toString(newConfiguration.get(USER_PIN_TOPIC)) == null ? null
+                : Coerce.toString(newConfiguration.get(USER_PIN_TOPIC)).toCharArray();
         if (!Arrays.equals(userPin, updatedUserPin)) {
             logger.atTrace().log("PKCS11 user pin changes, requires bootstrap");
             return true;


### PR DESCRIPTION
**Issue #, if available:**
Closes #29.

**Description of changes:**
Instead of casting to string, use coerce to string which is safe for all input types (such as Integer).

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
