### PR TITLE
fix: subscribe to configuration instead of child topics

### DIFF
--- a/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
+++ b/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
@@ -138,10 +138,29 @@ public class PKCS11CryptoKeyService extends PluginService implements CryptoKeySp
     protected void install() throws InterruptedException {
         try {
             super.install();
-            this.config.lookup(CONFIGURATION_CONFIG_KEY, NAME_TOPIC).subscribe(this::updateName);
-            this.config.lookup(CONFIGURATION_CONFIG_KEY, LIBRARY_TOPIC).subscribe(this::updateLibrary);
-            this.config.lookup(CONFIGURATION_CONFIG_KEY, SLOT_ID_TOPIC).subscribe(this::updateSlotId);
-            this.config.lookup(CONFIGURATION_CONFIG_KEY, USER_PIN_TOPIC).subscribe(this::updateUserPin);
+            this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((whatHappened, node) -> {
+                if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
+                    return;
+                }
+                logger.atDebug().kv("why", whatHappened).kv("node", node).log();
+                Topics configTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY);
+                if (whatHappened == WhatHappened.initialized) {
+                    updateName(whatHappened,configTopics.lookup(NAME_TOPIC));
+                    updateLibrary(whatHappened, configTopics.lookup(LIBRARY_TOPIC));
+                    updateSlotId(whatHappened, configTopics.lookup(SLOT_ID_TOPIC));
+                    updateUserPin(whatHappened, configTopics.lookup(USER_PIN_TOPIC));
+                    return;
+                }
+                if (node.childOf(LIBRARY_TOPIC)) {
+                    updateLibrary(whatHappened, configTopics.lookup(LIBRARY_TOPIC));
+                } else if (node.childOf(SLOT_ID_TOPIC)) {
+                    updateSlotId(whatHappened, configTopics.lookup(SLOT_ID_TOPIC));
+                } else if (node.childOf(USER_PIN_TOPIC)) {
+                    updateUserPin(whatHappened, configTopics.lookup(USER_PIN_TOPIC));
+                } else if (node.childOf(NAME_TOPIC)) {
+                    updateName(whatHappened,configTopics.lookup(NAME_TOPIC));
+                }
+            });
         } catch (IllegalArgumentException e) {
             throw new RuntimeException(String.format("Failed to install PKCS11CryptoKeyService. "
                     + "Make sure that configuration format for %s service is valid.", PKCS11_SERVICE_NAME));
@@ -165,37 +184,30 @@ public class PKCS11CryptoKeyService extends PluginService implements CryptoKeySp
 
 
     private void updateName(WhatHappened what, Topic topic) {
-        if (topic != null && what != WhatHappened.timestampUpdated) {
-            this.name = Coerce.toString(topic);
-            if (what != WhatHappened.initialized && !initializePkcs11Provider()) {
-                serviceErrored("Can't initialize PKCS11 JCA provider when name update");
-            }
+        this.name = Coerce.toString(topic);
+        if (what != WhatHappened.initialized && !initializePkcs11Provider()) {
+            serviceErrored("Can't initialize PKCS11 JCA provider when name update");
         }
     }
 
     private void updateLibrary(WhatHappened what, Topic topic) {
-        if (topic != null && what != WhatHappened.timestampUpdated) {
-            this.libraryPath = Coerce.toString(topic);
-            if (what != WhatHappened.initialized && (!initializePkcs11Lib() || !initializePkcs11Provider())) {
-                serviceErrored("Can't initialize PKCS11 when lib update");
-            }
+        this.libraryPath = Coerce.toString(topic);
+        if (what != WhatHappened.initialized && (!initializePkcs11Lib() || !initializePkcs11Provider())) {
+            serviceErrored("Can't initialize PKCS11 when lib update");
         }
     }
 
     private void updateSlotId(WhatHappened what, Topic topic) {
-        if (topic != null && what != WhatHappened.timestampUpdated) {
-            this.slotId = Coerce.toInt(topic);
-            if (what != WhatHappened.initialized && !initializePkcs11Provider()) {
-                serviceErrored("Can't initialize PKCS11 JCA provider when slot update");
-            }
+        this.slotId = Coerce.toInt(topic);
+        if (what != WhatHappened.initialized && !initializePkcs11Provider()) {
+            serviceErrored("Can't initialize PKCS11 JCA provider when slot update");
         }
     }
 
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     private void updateUserPin(WhatHappened what, Topic topic) {
-        if (topic != null && what != WhatHappened.timestampUpdated) {
-            String userPinStr = Coerce.toString(topic);
-            this.userPin = userPinStr == null ? null : userPinStr.toCharArray();
-        }
+        String userPinStr = Coerce.toString(topic);
+        this.userPin = userPinStr == null ? null : userPinStr.toCharArray();
     }
 
     private synchronized boolean initializePkcs11Lib() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Subscriptions to configuration nodes can be lost if configuration is RESET as part of a deployment. This change fixes that issue by subscribing to the root configuration node instead.

**Why is this change necessary:**
When we reset the configuration using [""], we lose subscriptions in the process.
Any further updates to the config are not parsed by PKCS11Provider

**How was this change tested:**
`mvn clean verify`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
