### PR TITLE
feat: add new API for getting certificate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.7.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.7.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Implements newly added API for getting the certificate using private key URI and certificate URI. 

**Why is this change necessary:**
This change enables getting the certificate directly without looking up for key aliases from key manager and then getting the certificate. 

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
