### PR TITLE
fix: move pkcs11 initialization into plugin startup instead of install

### DIFF
--- a/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
+++ b/src/main/java/com/aws/greengrass/security/provider/pkcs11/PKCS11CryptoKeyService.java
@@ -167,13 +167,14 @@ public class PKCS11CryptoKeyService extends PluginService implements CryptoKeySp
             throw new RuntimeException(String.format("Failed to install PKCS11CryptoKeyService. "
                     + "Make sure that configuration format for %s service is valid.", PKCS11_SERVICE_NAME));
         }
-        if (!initializePkcs11Lib() || !initializePkcs11Provider()) {
-            serviceErrored("Can't initialize PKCS11");
-        }
     }
 
     @Override
     protected void startup() throws InterruptedException {
+        if (!initializePkcs11Lib() || !initializePkcs11Provider()) {
+            serviceErrored("Can't initialize PKCS11");
+            return;
+        }
         try {
             securityService.registerCryptoKeyProvider(this);
             securityService.registerMqttConnectionProvider(this);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If the plugin shutsdown for whatever reason, it will close the PKCS11Lib that it creates. This lib is only created on `install` and when config changes, so if the plugin is restarted, the library would be permanently closed and unusable. This change simply moves it from the end of install into startup.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
